### PR TITLE
Fix_BaseRepository_V1

### DIFF
--- a/BoardCore/Extensions/AutofacModuleRegister.cs
+++ b/BoardCore/Extensions/AutofacModuleRegister.cs
@@ -1,10 +1,9 @@
 ﻿using Autofac;
+using IRepository.BaseIRespitory;
+using Repository.BaseRepository;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace BoardCore.Extensions
 {
@@ -25,6 +24,10 @@ namespace BoardCore.Extensions
             builder.RegisterAssemblyTypes(AssemblysRepository)
                        .AsImplementedInterfaces()
                        .InstancePerDependency();
+
+            builder.RegisterGeneric(typeof(BaseRepository<>)).As(typeof(IBaseRepository<>))
+                .AsImplementedInterfaces()
+                .InstancePerLifetimeScope();
         }
     }
 }

--- a/Models/Enitites/User.cs
+++ b/Models/Enitites/User.cs
@@ -5,7 +5,12 @@ using System.Collections.Generic;
 
 namespace Models.Enitites
 {
-    public partial class User
+    public class BaseEntity
+    {
+        public string Account { get; set; }
+    }
+
+    public partial class User : BaseEntity
     {
         public string Guid { get; set; }
         public string Account { get; set; }

--- a/Repository/BaseRepository/BaseRepository.cs
+++ b/Repository/BaseRepository/BaseRepository.cs
@@ -1,23 +1,21 @@
 ﻿using IRepository.BaseIRespitory;
 using Models.Enitites;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Repository.BaseRepository
 {
-    public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : class, new()
+    public class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : BaseEntity
     {
         private Context _context;
+
         public BaseRepository(Context context)
         {
             this._context = context;
         }
+
         public TEntity QueryByID(string ID, string PassWord)
         {
-            var query = _context.Users.Where(x => x.Account == ID).FirstOrDefault();
+            var query = _context.Set<TEntity>().Where(x => x.Account == ID).FirstOrDefault();
 
             return query;
         }


### PR DESCRIPTION
因 BaseRepository 是共用的泛型物件，不能直接回傳 指定的型別 ex: User

將查詢的物件 繼承 BaseEntity，供 BaseRepository Query欄位時使用